### PR TITLE
fix: escape 'no' in the flag lang file

### DIFF
--- a/themes/hello-friend-ng/data/langFlags.yaml
+++ b/themes/hello-friend-ng/data/langFlags.yaml
@@ -8,7 +8,7 @@ it: it
 ja: jp
 ml: in
 nl: nl
-no: no
+"no": "no"
 pt-br: br
 ru: ru
 tr: tr


### PR DESCRIPTION
@pomke no is interpreted as false by the yaml parser, it needs to be escaped.