### PR TITLE
Add company details to about page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -94,8 +94,17 @@ Blockchain & Crypto Advisor</div>
 
 </br></br>
 
---- 
+---
 
 These WOW doge PFPs were kindly made for us by the totally-amaze
 [@dogememegirl](https://twitter.com/Dogememegirl)! If you love them as
 much as we do give her a follow.
+
+---
+
+<div style="font-size: small; color: grey;">
+<span style="font-style: italic;">Dogecoin Foundation operating as MadeUpNumbers Ltd, a Registered Company in England & Wales</span><br />
+<span style="font-weight: bold;">Company Number:</span> 13602061<br />
+<span style="font-weight: bold;">Registered Address:</span> C/O Dac Beachcroft Llp,
+25 Walbrook, London, United Kingdom, EC4N 8AF
+</div>


### PR DESCRIPTION
Addresses this requirement: https://www.gov.uk/running-a-limited-company/signs-stationery-and-promotional-material
