### PR TITLE
Add a bit of padding to the locale

### DIFF
--- a/themes/hello-friend-ng/assets/scss/_locale.scss
+++ b/themes/hello-friend-ng/assets/scss/_locale.scss
@@ -21,6 +21,10 @@
       background-color: $dark-background;
     }
 
+    .lang-1 {
+      padding-left: 5px;
+    }
+
     .locale-list {
       display: block;
       position: absolute;


### PR DESCRIPTION
Right now, it looks like this. There is no padding between the flag and text. 
<img width="124" alt="Screen Shot 2022-01-01 at 11 24 10 AM" src="https://user-images.githubusercontent.com/72365100/147858545-95c565cf-fe88-4c81-8208-ccb42e5c72de.png">

This PR adds a bit of space between the flag and text.
<img width="121" alt="Screen Shot 2022-01-01 at 11 24 05 AM" src="https://user-images.githubusercontent.com/72365100/147858549-560f5c4f-eff8-4140-844d-e01de24f336f.png">

