### PR TITLE
Added link to Dogecoin Discord

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -170,6 +170,10 @@ disableHugoGeneratorInject = false
   [[params.social]]
     name = "reddit"
     url  = "https://www.reddit.com/r/dogecoindev"
+  
+  [[params.social]]
+    name = "discord"
+    url  = "https://discord.gg/dogecoin"
 
 [languages]
   [languages.en]


### PR DESCRIPTION
As it's currently missing in the footer, this adds the link to the Dogecoin Discord Server